### PR TITLE
wr435939 Update PHP Unit Tests

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -22,18 +22,18 @@
  * @copyright  2021 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
- 
+
 namespace block_surveylinks\privacy;
- 
+
 class provider implements \core_privacy\local\metadata\null_provider {
- 
+
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function get_reason() : string {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -23,8 +23,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Handle sending a file from the plugin.
  *
@@ -47,7 +45,7 @@ function block_surveylinks_pluginfile($course, $birecord, $context, $filearea, $
         $relativepath = implode('/', $args);
         $fullpath = "/{$context->id}/block_surveylinks/$filearea/$itemid/$relativepath";
         $fs = get_file_storage();
-        if (!$file = $fs->get_file_by_hash(sha1($fullpath)) or $file->is_directory()) {
+        if (!$file = $fs->get_file_by_hash(sha1($fullpath)) || $file->is_directory()) {
             return false;
         }
 

--- a/tests/block_surveylinks_test.php
+++ b/tests/block_surveylinks_test.php
@@ -23,19 +23,32 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_surveylinks;
+
+use context_system;
+use context_course;
+use moodle_url;
+
+defined('MOODLE_INTERNAL') || die();
+
 require_once(__DIR__ . '/../block_surveylinks.php');
 
-class block_surveylinks_block_testcase extends advanced_testcase {
-    
+/**
+ * Test the block definition.
+ */
+class block_surveylinks_test extends \advanced_testcase {
+
     /**
      * This method runs before every test.
      */
-    public function setUp() {
+    public function setUp(): void {
         $this->resetAfterTest();
     }
 
     /**
      * Test content is created when user can view survey links.
+     *
+     * @covers \block_surveylinks::get_content
      */
     public function test_get_content_when_expecting_survey_data() {
         global $COURSE;
@@ -47,13 +60,15 @@ class block_surveylinks_block_testcase extends advanced_testcase {
         $COURSE = $course;
         $this->assign_capability('block/surveylinks:viewmysurveylinks');
 
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $content = $block->get_content();
         $this->assertNotEmpty($content->text);
     }
 
     /**
      * Test content is not created when user cannot view survey links.
+     *
+     * @covers \block_surveylinks::get_content
      */
     public function test_get_content_when_missing_capability() {
         global $COURSE;
@@ -64,13 +79,15 @@ class block_surveylinks_block_testcase extends advanced_testcase {
         $this->setUser($user);
         $COURSE = $course;
 
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $content = $block->get_content();
         $this->assertNull($content);
     }
 
     /**
      * Test content is not created when user cannot view survey links.
+     *
+     * @covers \block_surveylinks::get_content
      */
     public function test_get_content_when_site_admin() {
         global $COURSE;
@@ -81,13 +98,15 @@ class block_surveylinks_block_testcase extends advanced_testcase {
         $COURSE = $course;
         $this->assign_capability('block/surveylinks:viewmysurveylinks');
 
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $content = $block->get_content();
         $this->assertNull($content);
     }
 
     /**
      * Test content is not created when user cannot view survey links.
+     *
+     * @covers \block_surveylinks::get_content
      */
     public function test_get_content_when_missing_plugin_settings() {
         global $COURSE;
@@ -97,13 +116,15 @@ class block_surveylinks_block_testcase extends advanced_testcase {
         $COURSE = $course;
         $this->assign_capability('block/surveylinks:viewmysurveylinks');
 
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $content = $block->get_content();
         $this->assertNull($content);
     }
 
     /**
      * Test content is not created when user cannot view survey links.
+     *
+     * @covers \block_surveylinks::get_content
      */
     public function test_get_content_when_missing_courseidnumber() {
         global $COURSE;
@@ -115,22 +136,26 @@ class block_surveylinks_block_testcase extends advanced_testcase {
         $COURSE = $course;
         $this->assign_capability('block/surveylinks:viewmysurveylinks');
 
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $content = $block->get_content();
         $this->assertNull($content);
     }
 
     /**
      * Test get default logo src.
+     *
+     * @covers \block_surveylinks::get_logo_src
      */
     public function test_get_get_logo_src_default() {
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $url = $block->get_logo_src();
         $this->assertEquals((new moodle_url('/blocks/surveylinks/pix/MyFeedback.jpg'))->out(), $url);
     }
 
     /**
      * Test get logo src stored in plugin filearea.
+     *
+     * @covers \block_surveylinks::get_logo_src
      */
     public function test_get_logo_src_config() {
         global $COURSE;
@@ -149,37 +174,41 @@ class block_surveylinks_block_testcase extends advanced_testcase {
         ];
         $file = $fs->create_file_from_string($filerecord, 'test');
 
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $block->config = (object) [
-            'logosrc' => '1234'
+            'logosrc' => '1234',
         ];
         $url = $block->get_logo_src();
         $this->assertEquals(moodle_url::make_file_url('/pluginfile.php', '/' . implode('/', [
-                $file->get_contextid(),
-                $file->get_component(),
-                $file->get_filearea(),
-                $file->get_itemid(),
-                $file->get_filepath(),
-                $file->get_filename(),
-            ])), $url);
+            $file->get_contextid(),
+            $file->get_component(),
+            $file->get_filearea(),
+            $file->get_itemid(),
+            $file->get_filepath(),
+            $file->get_filename(),
+        ])), $url);
     }
 
     /**
      * Test get default link text.
+     *
+     * @covers \block_surveylinks::get_link_text
      */
     public function test_get_link_text_default() {
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $text = $block->get_link_text();
         $this->assertEquals('', $text);
     }
 
     /**
      * Test get link defined in config.
+     *
+     * @covers \block_surveylinks::get_link_text
      */
     public function test_get_link_text_config() {
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $block->config = (object) [
-            'linktext' => 'helloworld'
+            'linktext' => 'helloworld',
         ];
         $text = $block->get_link_text();
         $this->assertEquals('helloworld', $text);
@@ -187,20 +216,24 @@ class block_surveylinks_block_testcase extends advanced_testcase {
 
     /**
      * Test get default extra text.
+     *
+     * @covers \block_surveylinks::get_extra_text
      */
     public function test_get_extra_text_default() {
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $text = $block->get_extra_text();
         $this->assertEquals('', $text);
     }
 
     /**
      * Test get extra defined in config.
+     *
+     * @covers \block_surveylinks::get_extra_text
      */
     public function test_get_extra_text_config() {
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $block->config = (object) [
-            'extratext' => 'helloworld'
+            'extratext' => 'helloworld',
         ];
         $text = $block->get_extra_text();
         $this->assertEquals('helloworld', $text);
@@ -223,13 +256,17 @@ class block_surveylinks_block_testcase extends advanced_testcase {
             $context = $context->id;
         }
         if (empty($this->roles)) {
-            $this->roles = array();
+            $this->roles = [];
         }
         if (empty($this->roles[$USER->id])) {
-            $this->roles[$USER->id] = array();
+            $this->roles[$USER->id] = [];
         }
         if (empty($this->roles[$USER->id][$context])) {
-            $this->roles[$USER->id][$context] = create_role('Role for '.$USER->id.' in '.$context, 'role'.$USER->id.'-'.$context, '-');
+            $this->roles[$USER->id][$context] = create_role(
+                'Role for ' . $USER->id . ' in ' . $context,
+                'role' . $USER->id . '-' . $context,
+                '-'
+            );
             role_assign($this->roles[$USER->id][$context], $USER->id, $context);
         }
         return $this->roles[$USER->id][$context];

--- a/tests/edit_form_test.php
+++ b/tests/edit_form_test.php
@@ -23,6 +23,15 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_surveylinks;
+
+use context_user;
+use context_course;
+use moodle_url;
+use stored_file;
+use stdClass;
+use block_base;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -31,17 +40,22 @@ require_once($CFG->libdir . "/blocklib.php");
 require_once($CFG->dirroot . "/blocks/surveylinks/edit_form.php");
 require_once($CFG->dirroot . "/blocks/surveylinks/block_surveylinks.php");
 
-class block_surveylinks_edit_form_testcase extends advanced_testcase {
+/**
+ * Test the configuration of the block.
+ */
+class edit_form_test extends \advanced_testcase {
 
     /**
      * This method runs before every test.
      */
-    public function setUp() {
+    public function setUp(): void {
         $this->resetAfterTest();
     }
 
     /**
      * Test clearing logo file.
+     *
+     * @covers \block_surveylinks_edit_form::clear_logo_file
      */
     public function test_clear_logo_file() {
         global $COURSE, $PAGE;
@@ -54,8 +68,10 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
         $this->assertNotNull($file);
         $this->assertInstanceOf(stored_file::class, $file);
         // Clear file, and check it is removed.
-        $blockedit = new block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
-                $this->get_mock_block_instance($course), $PAGE);
+        $blockedit = new \block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
+            $this->get_mock_block_instance($course),
+            $PAGE
+        );
         $COURSE = $course; // Need to reset the course as the block labyrinth sets it at some point.
         $blockedit->clear_logo_file();
         $file = $this->get_logo_file($course);
@@ -64,6 +80,8 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
 
     /**
      * Test clearing logo file if none exists.
+     *
+     * @covers \block_surveylinks_edit_form::clear_logo_file
      */
     public function test_clear_logo_file_if_none_exists() {
         global $COURSE, $PAGE;
@@ -74,8 +92,10 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
         $file = $this->get_logo_file($course);
         $this->assertNull($file);
         // Clear file, and check it is removed.
-        $blockedit = new block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
-            $this->get_mock_block_instance($course), $PAGE);
+        $blockedit = new \block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
+            $this->get_mock_block_instance($course),
+            $PAGE
+        );
         $COURSE = $course; // Need to reset the course as the block labyrinth sets it at some point.
         $blockedit->clear_logo_file();
         $file = $this->get_logo_file($course);
@@ -84,12 +104,14 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
 
     /**
      * Test clearing user draft file.
+     *
+     * @covers \block_surveylinks_edit_form::clear_user_draft_files
      */
     public function test_clear_user_draft_files() {
         global $COURSE, $PAGE;
         $course = $this->getDataGenerator()->create_course();
         $COURSE = $course;
-        $user = core_user::get_user(2);
+        $user = \core_user::get_user(2);
         $this->setAdminUser();
         $this->create_user_draft_file($user, '123456');
         // Check file exists.
@@ -97,8 +119,10 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
         $this->assertNotNull($file);
         $this->assertInstanceOf(stored_file::class, $file);
         // Clear file, and check it is removed.
-        $blockedit = new block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
-            $this->get_mock_block_instance($course), $PAGE);
+        $blockedit = new \block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
+            $this->get_mock_block_instance($course),
+            $PAGE
+        );
         $COURSE = $course; // Need to reset the course as the block labyrinth sets it at some point.
         $blockedit->clear_user_draft_files('123456');
         $file = $this->get_user_draft_file($user, '123456');
@@ -107,19 +131,23 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
 
     /**
      * Test clearing logo file if none exists.
+     *
+     * @covers \block_surveylinks_edit_form::clear_user_draft_files
      */
     public function test_clear_user_draft_files_if_none_exist() {
         global $COURSE, $PAGE;
         $course = $this->getDataGenerator()->create_course();
         $COURSE = $course;
-        $user = core_user::get_user(2);
+        $user = \core_user::get_user(2);
         $this->setAdminUser();
         // Check file doesn't exist.
         $file = $this->get_user_draft_file($user, '123456');
         $this->assertNull($file);
         // Clear file, and check it is removed.
-        $blockedit = new block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
-            $this->get_mock_block_instance($course), $PAGE);
+        $blockedit = new \block_surveylinks_edit_form((new moodle_url('/course/view.php', ['id' => $course->id])),
+            $this->get_mock_block_instance($course),
+            $PAGE
+        );
         $COURSE = $course; // Need to reset the course as the block labyrinth sets it at some point.
         $blockedit->clear_user_draft_files('123456');
         $file = $this->get_user_draft_file($user, '123456');
@@ -149,8 +177,14 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
     protected function get_user_draft_file(stdClass $user, string $itemid): ?stored_file {
         $fs = get_file_storage();
         $filerecord = $this->get_user_draft_file_record($user, $itemid);
-        $file = $fs->get_file($filerecord['contextid'], $filerecord['component'], $filerecord['filearea'],
-            $filerecord['itemid'], $filerecord['filepath'], $filerecord['filename']);
+        $file = $fs->get_file(
+            $filerecord['contextid'],
+            $filerecord['component'],
+            $filerecord['filearea'],
+            $filerecord['itemid'],
+            $filerecord['filepath'],
+            $filerecord['filename']
+        );
         if ($file === false) {
             return null;
         } else {
@@ -200,8 +234,14 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
     protected function get_logo_file(stdClass $course): ?stored_file {
         $fs = get_file_storage();
         $filerecord = $this->get_logo_file_record($course);
-        $file = $fs->get_file($filerecord['contextid'], $filerecord['component'], $filerecord['filearea'],
-                $filerecord['itemid'], $filerecord['filepath'], $filerecord['filename']);
+        $file = $fs->get_file(
+            $filerecord['contextid'],
+            $filerecord['component'],
+            $filerecord['filearea'],
+            $filerecord['itemid'],
+            $filerecord['filepath'],
+            $filerecord['filename']
+        );
         if ($file === false) {
             return null;
         } else {
@@ -250,7 +290,7 @@ class block_surveylinks_edit_form_testcase extends advanced_testcase {
             'timecreated' => 0,
             'timemodified' => 0,
         ];
-        $block = new block_surveylinks();
+        $block = new \block_surveylinks();
         $block->instance = $instance;
         $block->context = context_course::instance($course->id);
         return $block;

--- a/tests/event/http_request_failed_test.php
+++ b/tests/event/http_request_failed_test.php
@@ -25,28 +25,33 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_surveylinks\event;
+
 use block_surveylinks\event\http_request_failed;
 
-defined('MOODLE_INTERNAL') || die();
+/**
+ * Unit tests for the http_request_failed event.
+ */
+class http_request_failed_test extends \advanced_testcase {
 
-class block_surveylinks_http_request_failed_testcase extends advanced_testcase {
-    
     /**
      * This method runs before every test.
      */
-    public function setUp() {
+    public function setUp(): void {
         $this->resetAfterTest();
     }
 
     /**
      * Test the event was triggered.
+     *
+     * @covers \block_surveylinks\event\http_request_failed::trigger
      */
     public function test_event_is_triggered() {
         $sink = $this->redirectEvents();
         http_request_failed::create([
             'other' => [
                 'reason' => 'Test error message.',
-            ]
+            ],
         ])->trigger();
         $events = $sink->get_events();
         $this->assertCount(1, $events);

--- a/tests/explorance_api_test.php
+++ b/tests/explorance_api_test.php
@@ -23,22 +23,31 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace block_surveylinks;
+
 use block_surveylinks\explorance_api;
 use block_surveylinks\tests\mock_client;
 
-defined('MOODLE_INTERNAL') || die();
 
-class block_surveylinks_explorance_api_testcase extends advanced_testcase {
-    
+/**
+ * Test the explorance api.
+ */
+class explorance_api_test extends \advanced_testcase {
+
     /**
      * This method runs before every test.
      */
-    public function setUp() {
+    public function setUp(): void {
+        if (!defined('MOODLE_INTERNAL')) {
+            define('MOODLE_INTERNAL', true);
+        }
         $this->resetAfterTest();
     }
 
     /**
      * Test getting a list of survelink models.
+     *
+     * @covers \block_surveylinks\explorance_api::get_survey_links
      */
     public function test_get_survey_links() {
         set_config('apibaseuri', 'https://www.example.com', 'block_surveylinks');
@@ -56,32 +65,38 @@ class block_surveylinks_explorance_api_testcase extends advanced_testcase {
                 "surveySubjectId" => "123456",
                 "surveyUnitCode" => "ABC123",
                 "surveyCourseCode" => "A1234",
-            ])
+            ]),
         ];
         $this->assertEquals($expected, $surveylinks);
     }
 
     /**
      * Test exception thrown if api base uri is not set.
+     *
+     * @covers \block_surveylinks\explorance_api::__construct
      */
     public function test_invalid_base_uri_set() {
-        $this->expectException(moodle_exception::class);
+        $this->expectException(\moodle_exception::class);
         $this->expectExceptionMessage(get_string('error:api:nobaseuri', 'block_surveylinks'));
         $api = new explorance_api(new mock_client());
     }
 
     /**
      * Test exception thrown if api secret is not set.
+     *
+     * @covers \block_surveylinks\explorance_api::__construct
      */
     public function test_invalid_credentials_set() {
         set_config('apibaseuri', 'https://www.example.com', 'block_surveylinks');
-        $this->expectException(moodle_exception::class);
+        $this->expectException(\moodle_exception::class);
         $this->expectExceptionMessage(get_string('error:api:credentials', 'block_surveylinks'));
         $api = new explorance_api(new mock_client());
     }
 
     /**
      * Test extracting a subset of data from multidimensional array.
+     *
+     * @covers \block_surveylinks\explorance_api::get_subset_from_multidimensional_array
      */
     public function test_search_multidimensional_array() {
         $data = [
@@ -92,8 +107,8 @@ class block_surveylinks_explorance_api_testcase extends advanced_testcase {
                 ],
                 '1-2' => [
                     '1-2-1' => 1337,
-                    '1-2-2'  => new stdClass(),
-                ]
+                    '1-2-2'  => new \stdClass(),
+                ],
             ],
             2 => [
                 '2-1' => ['No key'],
@@ -101,7 +116,7 @@ class block_surveylinks_explorance_api_testcase extends advanced_testcase {
             [
                 '1-1' => 'Sibling 1-1 should not be found',
                 '1-1-2' => 'Shallow 1-1-2',
-            ]
+            ],
         ];
 
         $this->assertEquals('Hello World!', explorance_api::get_subset_from_multidimensional_array($data, '1-1-1'));
@@ -113,9 +128,12 @@ class block_surveylinks_explorance_api_testcase extends advanced_testcase {
         $this->assertEquals('Shallow 1-1-2', explorance_api::get_subset_from_multidimensional_array($data, '1-1-2'));
         // If there are multiple possible results at same depth, the first found should be returned.
         $this->assertEquals($data['1']['1-1'], explorance_api::get_subset_from_multidimensional_array($data, '1-1'));
-        $this->assertNotEquals('Sibling 1-1 should not be found', explorance_api::get_subset_from_multidimensional_array($data, '1-1'));
+        $this->assertNotEquals(
+            'Sibling 1-1 should not be found',
+            explorance_api::get_subset_from_multidimensional_array($data, '1-1')
+        );
         // Returned data should maintain type.
-        $this->assertInstanceOf(stdClass::class, explorance_api::get_subset_from_multidimensional_array($data, '1-2-2'));
+        $this->assertInstanceOf(\stdClass::class, explorance_api::get_subset_from_multidimensional_array($data, '1-2-2'));
         $this->assertIsArray(explorance_api::get_subset_from_multidimensional_array($data, '1-2'));
         // Non-string keys should also be matched.
         $this->assertCount(1, explorance_api::get_subset_from_multidimensional_array($data, 2));

--- a/tests/external/survey_links/get_test.php
+++ b/tests/external/survey_links/get_test.php
@@ -23,17 +23,26 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-class block_surveylinks_get_survey_links_testcase extends advanced_testcase {
+namespace block_surveylinks\external\survey_links;
+
+use moodle_exception;
+
+/**
+ * Test the get_survey_links external function.
+ */
+class get_test extends \advanced_testcase {
 
     /**
      * Run before every test.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         $this->resetAfterTest();
     }
 
     /**
      * Check get if user does not have a idnumber.
+     *
+     * @covers \block_surveylinks\external\survey_links\get::get
      */
     public function test_get_surveylinks_user_not_found() {
         $course = $this->getDataGenerator()->create_course(['idnumber' => 'course123']);
@@ -44,6 +53,8 @@ class block_surveylinks_get_survey_links_testcase extends advanced_testcase {
 
     /**
      * Check get if course does not have a idnumber.
+     *
+     * @covers \block_surveylinks\external\survey_links\get::get
      */
     public function test_get_surveylinks_course_not_found() {
         $user = $this->getDataGenerator()->create_user(['idnumber' => 'user123']);
@@ -54,6 +65,8 @@ class block_surveylinks_get_survey_links_testcase extends advanced_testcase {
 
     /**
      * Test survey is available.
+     *
+     * @covers \block_surveylinks\external\survey_links\get::is_survey_available
      */
     public function test_survey_is_available() {
         $surveylink = new \block_surveylinks\surveylink_model([
@@ -74,6 +87,7 @@ class block_surveylinks_get_survey_links_testcase extends advanced_testcase {
      * Test that survey is not available.
      *
      * @dataProvider closed_survey_provider
+     * @covers \block_surveylinks\external\survey_links\get::is_survey_available
      */
     public function test_survey_is_not_available(\block_surveylinks\surveylink_model $surveylink) {
         $result = \block_surveylinks\external\survey_links\get::is_survey_available($surveylink);
@@ -82,6 +96,8 @@ class block_surveylinks_get_survey_links_testcase extends advanced_testcase {
 
     /**
      * Test unit code from survey matches Moodle course.
+     *
+     * @covers \block_surveylinks\external\survey_links\get::survey_matches_course
      */
     public function test_survey_matches_course() {
         $course = $this->getDataGenerator()->create_course(['idnumber' => 'UNIT123']);
@@ -101,6 +117,8 @@ class block_surveylinks_get_survey_links_testcase extends advanced_testcase {
 
     /**
      * Test unit code from survey does not match Moodle course.
+     *
+     * @covers \block_surveylinks\external\survey_links\get::survey_matches_course
      */
     public function test_survey_does_not_match_course() {
         $course = $this->getDataGenerator()->create_course(['idnumber' => 'UNIT456']);
@@ -123,7 +141,7 @@ class block_surveylinks_get_survey_links_testcase extends advanced_testcase {
      *
      * @return array [surveylink_model]
      */
-    public function closed_survey_provider(): array {
+    public static function closed_survey_provider(): array {
         return [
             'Future survey' => [new \block_surveylinks\surveylink_model([
                 'surveyId' => '1324',

--- a/tests/privacy/provider_test.php
+++ b/tests/privacy/provider_test.php
@@ -23,17 +23,24 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-class block_surveylinks_provider_testcase extends advanced_testcase {
-    
+namespace block_surveylinks\privacy;
+
+/**
+ * Test the plugin privacy provider implementation.
+ */
+class provider_test extends \advanced_testcase {
+
     /**
      * This method runs before every test.
      */
-    public function setUp() {
+    public function setUp(): void {
         $this->resetAfterTest();
     }
 
     /**
      * Test the provider get_message implementation.
+     *
+     * @covers \block_surveylinks\privacy\provider::get_message
      */
     public function test_get_null_provider_message() {
         $this->assertEquals('privacy:metadata', \block_surveylinks\privacy\provider::get_reason());

--- a/tests/surveylink_model_test.php
+++ b/tests/surveylink_model_test.php
@@ -23,17 +23,24 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-class block_surveylinks_surveylink_model_testcase extends advanced_testcase {
+namespace block_surveylinks;
+
+/**
+ * Test the surveylink model.
+ */
+class surveylink_model_test extends \advanced_testcase {
 
     /**
      * This method runs before every test.
      */
-    public function setUp() {
+    public function setUp(): void {
         $this->resetAfterTest();
     }
 
     /**
      * Test creating model with valid data record.
+     *
+     * @covers \block_surveylinks\surveylink_model::create_model_with_valid_data
      */
     public function test_create_model_with_valid_data() {
         $surveylink = new \block_surveylinks\surveylink_model([
@@ -57,6 +64,8 @@ class block_surveylinks_surveylink_model_testcase extends advanced_testcase {
 
     /**
      * Test creating model with empty data.
+     *
+     * @covers \block_surveylinks\surveylink_model::create_model_with_empty_data
      */
     public function test_create_model_with_no_data() {
         $surveylink = new \block_surveylinks\surveylink_model([]);
@@ -67,6 +76,8 @@ class block_surveylinks_surveylink_model_testcase extends advanced_testcase {
 
     /**
      * Test creating model with data not expected by model.
+     *
+     * @covers \block_surveylinks\surveylink_model::create_model_with_invalid_data
      */
     public function test_create_model_with_invalid_data() {
         $surveylink = new \block_surveylinks\surveylink_model([


### PR DESCRIPTION
This pull request addresses a compatibility issue with the PHPUnit `setUp()` method in  test classes within the `block_surveylinks_testsuite`. 

The proposed changes in this PR aim to resolve this [issue](https://github.com/MURBASLMS/block_surveylinks/issues/2), ensuring the `setUp()` methods in the affected test classes are compatible with the `PHPUnit` framework. 

Please review and provide feedback.

